### PR TITLE
Allow to change gulp executable.

### DIFF
--- a/lib/capistrano/tasks/gulp.rake
+++ b/lib/capistrano/tasks/gulp.rake
@@ -5,6 +5,7 @@ desc <<-DESC
 
     You can override any of these defaults by setting the variables shown below.
 
+      set :gulp_executable, 'gulp'
       set :gulp_file, nil
       set :gulp_tasks, nil
       set :gulp_flags, '--no-color'
@@ -21,7 +22,7 @@ task :gulp do
       options << "--gulpfile #{fetch(:gulp_file)}" if fetch(:gulp_file)
       options << fetch(:gulp_tasks) if fetch(:gulp_tasks)
 
-      execute :gulp, options
+      execute fetch(:gulp_executable), options
     end
   end
 end
@@ -32,6 +33,7 @@ end
 
 namespace :load do
   task :defaults do
+    set :gulp_executable, 'gulp'
     set :gulp_file, nil
     set :gulp_tasks, nil
     set :gulp_flags, '--no-color'


### PR DESCRIPTION
Very useful if your don't have gulp installed globally. If you use `npm` to install gulp locally into your project you must use `./gulp` to execute gulp instead of the global command line `gulp`.
