### PR TITLE
"Don't know how to build task 'updated'"-error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Capistrano::Gulp
 
-This gem will let you run [Gulp](http://gulptjs.com/) tasks with Capistrano 3.x.
+This gem will let you run [Gulp](http://gulpjs.com/) tasks with Capistrano 3.x.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ gulp deploy:production cdn
 Then add the task to your `deploy.rb`:
 
 ```ruby
-before :updated, 'gulp'
+before 'deploy:updated', 'gulp'
 ```
 
 ## Configuration


### PR DESCRIPTION
Putting `before :updated, 'gulp'` into deploy.rb caused the error "Don't know how to build task 'updated'" when deploying. Writing `before 'deploy:updated', 'gulp'` instead fixes it.

Capistrano Version: 3.3.5 (Rake Version: 10.4.2) 
