### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ gulp deploy:production cdn
 Then add the task to your `deploy.rb`:
 
 ```ruby
-before :updated, 'gulp'
+namespace :deploy do
+  before :updated, 'gulp'
+end
 ```
 
 ## Configuration


### PR DESCRIPTION
`before :updated` hook is only available in `:deploy` namespace. Otherwise it won't work.
